### PR TITLE
Campinas/SP - implementação inicial

### DIFF
--- a/data_collection/gazette/gazette/spiders/sp_campinas.py
+++ b/data_collection/gazette/gazette/spiders/sp_campinas.py
@@ -36,8 +36,8 @@ class SpCampinasSpider(scrapy.Spider):
             date = parse(f'{day} {month_year}', languages=['pt']).date()
             url = f'{self.sp_campinas_url}{url}'
 
-            is_extra_edition = False # campinas does not have extra edition nor explicit power division (one pdf handles both)
-            power = 'executive'
+            is_extra_edition = False
+            power = 'executive_legislature'
             items.append(
                 Gazette(
                     date=date,

--- a/data_collection/gazette/gazette/spiders/sp_campinas.py
+++ b/data_collection/gazette/gazette/spiders/sp_campinas.py
@@ -23,7 +23,6 @@ class SpCampinas(scrapy.Spider):
                 if year == today.year and month > today.month:
                     continue
                 url = self.selector_url.format(month, year)
-                print(year, month, url)
                 yield scrapy.Request(url, self.parse_month_page)
 
 
@@ -36,7 +35,7 @@ class SpCampinas(scrapy.Spider):
             dia = diario.css('::text').extract_first()
             date = parse(f'{dia} {mesAno}', languages=['pt']).date()
             url = f'{self.sp_campinas_url}{link}'
-            
+            # campinas does not have neither extra edition nor explicit power division (one pdf handles both)
             is_extra_edition = False
             power = 'executive'
             items.append(
@@ -46,31 +45,7 @@ class SpCampinas(scrapy.Spider):
                     is_extra_edition=is_extra_edition,
                     municipality_id=self.MUNICIPALITY_ID,
                     scraped_at=dt.datetime.utcnow(),
-                    power=power,
+                    power=power
                 )
             )
         return items
-
-        #links = response.css('#conteudo a')
-        #for link in links:
-        #    url = link.css('::attr(href)').extract_first()
-        #    if url[-4:] != '.pdf':
-        #        continue
-        #    
-        #    url = response.urljoin(url)
-        #    power = 'executive' if 'executivo' in url.lower() else 'legislature'
-        #    date = link.css('::text').extract_first()
-        #    is_extra_edition = 'extra' in date.lower()
-        #    date = parse(date.split('-')[0], languages=['pt']).date()
-        #    items.append(
-        #        Gazette(
-        #            date=date,
-        #            file_urls=[url],
-        #            is_extra_edition=is_extra_edition,
-        #            municipality_id=self.MUNICIPALITY_ID,
-        #            scraped_at=dt.datetime.utcnow(),
-        #            power=power,
-        #        )
-        #    )
-        #print(items)
-        return []

--- a/data_collection/gazette/gazette/spiders/sp_campinas.py
+++ b/data_collection/gazette/gazette/spiders/sp_campinas.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from dateparser import parse
+import datetime as dt
+
+import scrapy
+
+from gazette.items import Gazette
+
+
+class SpCampinas(scrapy.Spider):
+    MUNICIPALITY_ID = '3509502'
+    name = 'sp_campinas'
+    allowed_domains = ['campinas.sp.gov.br']
+    start_urls = ['http://www.campinas.sp.gov.br/diario-oficial/index.php']
+    sp_campinas_url = 'http://www.campinas.sp.gov.br/'
+    selector_url = 'http://www.campinas.sp.gov.br/diario-oficial/index.php?mes={}&ano={}'
+
+    def parse(self, response):
+        today = dt.date.today()
+        next_year = today.year + 1
+        for year in range(2018, next_year):
+            for month in range(1, 13):
+                if year == today.year and month > today.month:
+                    continue
+                url = self.selector_url.format(month, year)
+                print(year, month, url)
+                yield scrapy.Request(url, self.parse_month_page)
+
+
+    def parse_month_page(self, response):
+        items = []
+        mesAno = response.css(".tabelaDiario:first-child tr th:nth-child(2)::text").extract_first()
+        diarios = response.css(".tabelaDiario:first-child tr td a")
+        for diario in diarios:
+            link = diario.css('::attr(href)').extract_first().replace('../', '')
+            dia = diario.css('::text').extract_first()
+            date = parse(f'{dia} {mesAno}', languages=['pt']).date()
+            url = f'{self.sp_campinas_url}{link}'
+            
+            is_extra_edition = False
+            power = 'executive'
+            items.append(
+                Gazette(
+                    date=date,
+                    file_urls=[url],
+                    is_extra_edition=is_extra_edition,
+                    municipality_id=self.MUNICIPALITY_ID,
+                    scraped_at=dt.datetime.utcnow(),
+                    power=power,
+                )
+            )
+        return items
+
+        #links = response.css('#conteudo a')
+        #for link in links:
+        #    url = link.css('::attr(href)').extract_first()
+        #    if url[-4:] != '.pdf':
+        #        continue
+        #    
+        #    url = response.urljoin(url)
+        #    power = 'executive' if 'executivo' in url.lower() else 'legislature'
+        #    date = link.css('::text').extract_first()
+        #    is_extra_edition = 'extra' in date.lower()
+        #    date = parse(date.split('-')[0], languages=['pt']).date()
+        #    items.append(
+        #        Gazette(
+        #            date=date,
+        #            file_urls=[url],
+        #            is_extra_edition=is_extra_edition,
+        #            municipality_id=self.MUNICIPALITY_ID,
+        #            scraped_at=dt.datetime.utcnow(),
+        #            power=power,
+        #        )
+        #    )
+        #print(items)
+        return []

--- a/data_collection/gazette/gazette/spiders/sp_campinas.py
+++ b/data_collection/gazette/gazette/spiders/sp_campinas.py
@@ -7,7 +7,7 @@ import scrapy
 from gazette.items import Gazette
 
 
-class SpCampinas(scrapy.Spider):
+class SpCampinasSpider(scrapy.Spider):
     MUNICIPALITY_ID = '3509502'
     name = 'sp_campinas'
     allowed_domains = ['campinas.sp.gov.br']

--- a/data_collection/gazette/gazette/spiders/sp_campinas.py
+++ b/data_collection/gazette/gazette/spiders/sp_campinas.py
@@ -21,7 +21,7 @@ class SpCampinas(scrapy.Spider):
         for year in range(2015, next_year):
             for month in range(1, 13):
                 if year == today.year and month > today.month:
-                    continue
+                    return
                 url = self.selector_url.format(month, year)
                 yield scrapy.Request(url, self.parse_month_page)
 

--- a/data_collection/gazette/gazette/spiders/sp_campinas.py
+++ b/data_collection/gazette/gazette/spiders/sp_campinas.py
@@ -18,7 +18,7 @@ class SpCampinas(scrapy.Spider):
     def parse(self, response):
         today = dt.date.today()
         next_year = today.year + 1
-        for year in range(2018, next_year):
+        for year in range(2015, next_year):
             for month in range(1, 13):
                 if year == today.year and month > today.month:
                     continue
@@ -28,15 +28,15 @@ class SpCampinas(scrapy.Spider):
 
     def parse_month_page(self, response):
         items = []
-        mesAno = response.css(".tabelaDiario:first-child tr th:nth-child(2)::text").extract_first()
-        diarios = response.css(".tabelaDiario:first-child tr td a")
-        for diario in diarios:
-            link = diario.css('::attr(href)').extract_first().replace('../', '')
-            dia = diario.css('::text').extract_first()
-            date = parse(f'{dia} {mesAno}', languages=['pt']).date()
-            url = f'{self.sp_campinas_url}{link}'
-            # campinas does not have neither extra edition nor explicit power division (one pdf handles both)
-            is_extra_edition = False
+        month_year = response.css(".tabelaDiario:first-child tr th:nth-child(2)::text").extract_first() # "janeiro 2018"
+        links = response.css(".tabelaDiario:first-child tr td a")
+        for link in links:
+            url = link.css('::attr(href)').extract_first().replace('../', '')
+            day = link.css('::text').extract_first()
+            date = parse(f'{day} {month_year}', languages=['pt']).date()
+            url = f'{self.sp_campinas_url}{url}'
+
+            is_extra_edition = False # campinas does not have extra edition nor explicit power division (one pdf handles both)
             power = 'executive'
             items.append(
                 Gazette(


### PR DESCRIPTION
Segue uma implementação inicial do crawler para Campinas/SP.

Dúvida: o site do portal da transparência de Campinas não separa os diários dos poderes executivo e legislativo. Disponibilizam um único PDF. Como lidar com esta situação?
Acredito que várias situações semelhantes acontecerão em outras cidades.

http://www.campinas.sp.gov.br/diario-oficial/index.php